### PR TITLE
Revert "Adding Configuration Clarification in Atom S3 Config File"

### DIFF
--- a/config/config_atom-s3-lite-esp32-s3.yaml
+++ b/config/config_atom-s3-lite-esp32-s3.yaml
@@ -10,16 +10,9 @@
 # +--------------------------------------+
 # | ESP32 CAN/serial port pins           |
 # +--------------------------------------+
-# GPIO pins your CAN bus transceiver
-# Using ATOMIC CANBus Base (CA-IS3050G) - SKU: A103
+# GPIO pins your CAN bus transceiver ATOMIC CANBus Base (CA-IS3050G)
   can_tx_pin: GPIO5
   can_rx_pin: GPIO6
-
-# Using CANBus Unit (CA-IS3050G) - SKU: U085
-  can_tx_pin: GPIO2
-  can_rx_pin: GPIO1
-
-
 # GPIO pins your JK-BMS UART-TTL is connected to the grove port of Atom Lite
   tx_pin: GPIO1
   rx_pin: GPIO2


### PR DESCRIPTION
Reverts Sleeper85/esphome-jk-bms-can#36

Even if the CAN bus adapter you purchased is compatible. This is not the one we recommend using (question of simplicity). In the future packaged version there will be YAML for Atom S3 Lite / Display and ATOMIC CANBus Base (CA-IS3050G) - SKU: A103 is the base used by default. GPIOs 1 and 2 are those reserved for the UART JK-BMS connection. I just don't want to add even more complexity. I hope you understand my decision.